### PR TITLE
Add baseline evaluation and cross-validation options

### DIFF
--- a/config.py
+++ b/config.py
@@ -58,7 +58,7 @@ MODEL_CONFIG = {
     
     # Training settings - More aggressive training
     "batch_size": 16,          # Smaller batches for better learning
-    "learning_rate": 5e-4,     # Higher learning rate
+    "learning_rate": 1e-4,     # Lower learning rate for stability
     "epochs": 150,             # More epochs
     "validation_split": 0.1,
     "test_split": 0.1,


### PR DESCRIPTION
## Summary
- Reduce transformer training learning rate for improved stability
- Add naive baseline evaluation and time series cross-validation helpers
- Record baseline metrics in training pipeline output

## Testing
- `python -m py_compile config.py scripts/training.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4cdda5cf8832ebfd9df950aa16789